### PR TITLE
Allow default to be set for a serialized column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # TBA
 
 - Ensure that behaviour remains the same as `ActiveRecord::Base` when no attributes are defined
+- Allow options to be passed in with `include Storext.model`
 
 # 0.1.4
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Define the attributes:
 ```ruby
 class Book < ActiveRecord::Base
 
-  include Storext
+  include Storext.model
 
   # You can define attributes on the :data hstore column like this:
   store_attributes :data do
@@ -43,6 +43,14 @@ class Book < ActiveRecord::Base
   store_attribute :data, :hardcover, Boolean
   store_attribute :data, :alt_name
 
+end
+```
+
+You can also set defaults (useful when you want to default a serialized column to be an empty hash (`{}`)):
+
+```ruby
+class Book < ActiveRecord::Base
+  include Storext.model(data: {})
 end
 ```
 

--- a/lib/storext.rb
+++ b/lib/storext.rb
@@ -6,6 +6,14 @@ require "storext/instance_methods"
 
 module Storext
 
+  def self.model(*options)
+    mod = Module.new do
+      def self.included(base)
+        base.send :include, Storext
+      end
+    end
+  end
+
   extend ActiveSupport::Concern
 
   included do

--- a/lib/storext.rb
+++ b/lib/storext.rb
@@ -6,18 +6,32 @@ require "storext/instance_methods"
 
 module Storext
 
-  def self.model(*options)
+  def self.model(options={})
     mod = Module.new do
+      mattr_accessor :storext_options
+
       def self.included(base)
+        base.class_attribute :storext_options
+        base.storext_options = self.storext_options
         base.send :include, Storext
       end
     end
+
+    mod.storext_options = options
+
+    mod
   end
 
   extend ActiveSupport::Concern
 
   included do
     include InstanceMethods
+
+    unless respond_to?(:storext_options)
+      warn "Storext must be included via `include Storext.model` instead. Not specifying `.model` has been deprecated. (included from #{self.to_s})"
+      class_attribute :storext_options
+      self.storext_options = {}
+    end
 
     class_attribute :store_attribute_defs
     self.store_attribute_defs = {}
@@ -27,6 +41,12 @@ module Storext
     end
 
     after_initialize :set_storext_defaults
+
+    self.storext_options.each do |column, default|
+      self.send :define_method, column do
+        self.read_attribute(column) || default
+      end
+    end
   end
 
 end

--- a/spec/dummy/app/models/author.rb
+++ b/spec/dummy/app/models/author.rb
@@ -1,6 +1,6 @@
 class Author < ActiveRecord::Base
 
-  include Storext
+  include Storext.model
   store_attributes :data do
     name String
     title String, default: "Dr."

--- a/spec/dummy/app/models/book.rb
+++ b/spec/dummy/app/models/book.rb
@@ -1,6 +1,6 @@
 class Book < ActiveRecord::Base
 
-  include Storext
+  include Storext.model
   store_attributes :data do
     author String
     title String, default: "Great Voyage"

--- a/spec/dummy/app/models/car.rb
+++ b/spec/dummy/app/models/car.rb
@@ -1,5 +1,5 @@
 class Car < ActiveRecord::Base
 
-  include Storext
+  include Storext.model
 
 end

--- a/spec/dummy/app/models/coffee.rb
+++ b/spec/dummy/app/models/coffee.rb
@@ -1,0 +1,9 @@
+class Coffee < ActiveRecord::Base
+
+  include Storext.model
+
+  store_attributes :data do
+    name String
+  end
+
+end

--- a/spec/dummy/app/models/coffee.rb
+++ b/spec/dummy/app/models/coffee.rb
@@ -1,6 +1,6 @@
 class Coffee < ActiveRecord::Base
 
-  include Storext.model
+  include Storext.model(data: {})
 
   store_attributes :data do
     name String

--- a/spec/dummy/app/models/phone.rb
+++ b/spec/dummy/app/models/phone.rb
@@ -1,6 +1,6 @@
 class Phone < ActiveRecord::Base
 
-  include Storext
+  include Storext.model
   store_attributes :data do
     number String, default: "222"
   end

--- a/spec/dummy/db/migrate/20150130013803_create_coffees.rb
+++ b/spec/dummy/db/migrate/20150130013803_create_coffees.rb
@@ -1,0 +1,7 @@
+class CreateCoffees < ActiveRecord::Migration
+  def change
+    create_table :coffees do |t|
+      t.hstore :data
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150113011502) do
+ActiveRecord::Schema.define(version: 20150130013803) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,10 @@ ActiveRecord::Schema.define(version: 20150113011502) do
   end
 
   create_table "cars", force: true do |t|
+    t.hstore "data"
+  end
+
+  create_table "coffees", force: true do |t|
     t.hstore "data"
   end
 

--- a/spec/storext_spec.rb
+++ b/spec/storext_spec.rb
@@ -2,6 +2,11 @@ require 'spec_helper'
 
 describe Storext do
 
+  it "can import with preferences" do
+    coffee = Coffee.new(name: "Arabica")
+    expect(coffee.name).to eq "Arabica"
+  end
+
   describe ".store_attributes" do
     it "allows definition of multiple attributes" do
       book = Book.create

--- a/spec/storext_spec.rb
+++ b/spec/storext_spec.rb
@@ -7,6 +7,12 @@ describe Storext do
     expect(coffee.name).to eq "Arabica"
   end
 
+  it "can set default value for the serialized column" do
+    coffee = Coffee.new
+    coffee.update_attributes(data: nil)
+    expect(coffee.data).to eq({})
+  end
+
   describe ".store_attributes" do
     it "allows definition of multiple attributes" do
       book = Book.create
@@ -55,7 +61,7 @@ describe Storext do
         self.table_name = "authors"
         self::Boolean = "Something"
 
-        include Storext
+        include Storext.model
         store_attributes :data do
           name String
         end
@@ -69,7 +75,7 @@ describe Storext do
           self.table_name = "authors"
           Boolean = "Something"
 
-          include Storext
+          include Storext.model
           store_attributes :data do
             name String
             alive Boolean


### PR DESCRIPTION
Useful when you want the serialized column to be an empty hash