### PR TITLE
When a value is coerced, store the coerced value. fixes #16

### DIFF
--- a/lib/storext/class_methods.rb
+++ b/lib/storext/class_methods.rb
@@ -3,9 +3,11 @@ module Storext
 
     def storext_define_writer(column, attr)
       define_method "#{attr}=" do |value|
+        coerced_value = storext_cast_proxy.send("#{attr}=", value)
+
         send("#{column}=", send(column) || {})
-        write_store_attribute column, attr, value
-        send(column)[attr.to_s] = value
+        write_store_attribute column, attr, coerced_value
+        send(column)[attr.to_s] = coerced_value
       end
     end
 

--- a/spec/storext_spec.rb
+++ b/spec/storext_spec.rb
@@ -44,6 +44,22 @@ describe Storext do
       book = Book.new
       expect(book.isbn).to eq "Computed ISBN"
     end
+
+    it "can properly coerce truthy boolean values" do
+      book = Book.new
+      book.hardcover = "1"
+
+      expect(book.data['hardcover']).to eq true
+      expect(book.hardcover).to eq true
+    end
+
+    it "can properly coerce falsey boolean values" do
+      book = Book.new
+      book.hardcover = "0"
+
+      expect(book.data['hardcover']).to eq false
+      expect(book.hardcover).to eq false
+    end
   end
 
   describe ".storext_definitions" do


### PR DESCRIPTION
Currently, Virtus is coercing values for us. But we're storing the original value instead of the coerced value. So we end up with a different value in the database than we see in the model.

Biggest win for this change is that it will make booleans work exactly like they do in Rails. :smile:

When a `"1"` or `"0"` is set from a form, it will be converted and stored as `true` or `false`.