### PR TITLE
add predicate method for all types of attributes

### DIFF
--- a/lib/storext/class_methods.rb
+++ b/lib/storext/class_methods.rb
@@ -21,6 +21,13 @@ module Storext
       end
     end
 
+    def storext_define_predicater(column, attr)
+      define_method "#{attr}?" do
+        return false unless send(column) && send(column).has_key?(attr.to_s)
+        !!read_store_attribute(column, attr)
+      end
+    end
+
     def store_attribute(column, attr, type=nil, opts={})
       track_store_attribute(column, attr, type, opts)
       storext_check_attr_validity(attr, type, opts)
@@ -31,6 +38,7 @@ module Storext
     def storext_define_accessor(column, attr)
       storext_define_writer(column, attr)
       storext_define_reader(column, attr)
+      storext_define_predicater(column, attr)
       storext_define_proxy_attribute(attr)
     end
 

--- a/spec/storext_spec.rb
+++ b/spec/storext_spec.rb
@@ -60,6 +60,19 @@ describe Storext do
       expect(book.data['hardcover']).to eq false
       expect(book.hardcover).to eq false
     end
+
+    it "can access predicater methods for all attributes (with or without defaults)" do
+      book = Book.new
+      book.preface = nil
+      book.alt_name = "Great Travel"
+
+      expect(book.author?).to eq false      # no default
+      expect(book.available?).to eq true    # true als default
+      expect(book.title?).to eq true        # "Great Voyage" as default
+      expect(book.copies?).to eq true       # 0 as default
+      expect(book.preface?).to eq false     # set to nil above
+      expect(book.alt_name?).to eq true     # set to "Great Travel" above
+    end
   end
 
   describe ".storext_definitions" do


### PR DESCRIPTION
as discussed here: https://github.com/G5/storext/issues/15

adds predicate methods (object.some_setting?) to all kinds of attributes to return true or false.