### PR TITLE
fixed prediacter methods so that empty string return false

### DIFF
--- a/lib/storext/class_methods.rb
+++ b/lib/storext/class_methods.rb
@@ -24,7 +24,11 @@ module Storext
     def storext_define_predicater(column, attr)
       define_method "#{attr}?" do
         return false unless send(column) && send(column).has_key?(attr.to_s)
-        !!read_store_attribute(column, attr)
+        if read_store_attribute(column, attr).is_a? String
+          !read_store_attribute(column, attr).blank?
+        else
+          !!read_store_attribute(column, attr)
+        end
       end
     end
 

--- a/spec/storext_spec.rb
+++ b/spec/storext_spec.rb
@@ -72,6 +72,9 @@ describe Storext do
       expect(book.copies?).to eq true       # 0 as default
       expect(book.preface?).to eq false     # set to nil above
       expect(book.alt_name?).to eq true     # set to "Great Travel" above
+
+      book.alt_name = ""
+      expect(book.alt_name?).to eq false     # empty string should return false
     end
   end
 


### PR DESCRIPTION
I found a small bug in my last pull request which added the predicater methods: if you got an empty string like book.title = "" than book.title? will return TRUE - but should return FALSE!

The mistake was using _!!value_ for all attributes, because in plain ruby
````ruby
empty_string = ""
=> ""
!!empty_string
=> true
````

But Rails ActiveRecord does not simply use _!!value_ - it differs between types and if the type is a string than it uses _!value.blank?_ ... which is much better because of course if we check an object attribute with an emtpy string we want

````ruby
book.title = ""
=> ""
book.title?
=> false
````

