### PR TITLE
Clear values from proxy object when deleting keys on storext object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Reset values on proxy object when keys are destroyed on a storext object. Keeping these values leads to surprising behavior. See:
+
+https://github.com/G5/storext-override/issues/8
+
 ## [2.2.1] - 2016-08-31
 ### Fixed
 - Predicater methods for strings returns `false` when blank

--- a/lib/storext/instance_methods.rb
+++ b/lib/storext/instance_methods.rb
@@ -7,6 +7,8 @@ module Storext
         new_value = send(column).dup
       end
       new_value.delete(attr.to_s)
+      storext_cast_proxy.reset_attribute(attr)
+
       send("#{column}=", new_value)
     end
 
@@ -15,7 +17,12 @@ module Storext
       if Rails.gem_version < Gem::Version.new("4.2.0")
         new_value = send(column).dup
       end
-      attrs.each { |a| new_value.delete(a.to_s) }
+
+      attrs.each do |a|
+        new_value.delete(a.to_s)
+        storext_cast_proxy.reset_attribute(a)
+      end
+
       send("#{column}=", new_value)
     end
 

--- a/spec/storext_spec.rb
+++ b/spec/storext_spec.rb
@@ -208,6 +208,16 @@ describe Storext do
       expect(book.data).to have_key("author")
     end
 
+    it "clears the value from the proxy object" do
+      book = Book.create(author: "Chico's", title: "Foo and Bar")
+
+      book.destroy_key(:data, :author)
+      expect(book.author).to be_nil
+
+      book.destroy_key(:data, :title)
+      expect(book.title).to eq "Great Voyage"
+    end
+
     it "updates the changes when saved" do
       book = Book.create
       book.data = {'hulla' => 'balloo'}
@@ -229,6 +239,14 @@ describe Storext do
       book.reload
       expect(book.data).to have_key("author")
       expect(book.data).to have_key("title")
+    end
+
+    it "clears the values from the proxy object" do
+      book = Book.create(author: "Chico's", title: "Foo and Bar")
+      book.destroy_keys(:data, :author, :title)
+
+      expect(book.author).to be_nil
+      expect(book.title).to eq "Great Voyage"
     end
 
     it "updates the changes when saved" do

--- a/spec/storext_spec.rb
+++ b/spec/storext_spec.rb
@@ -209,13 +209,14 @@ describe Storext do
     end
 
     it "clears the value from the proxy object" do
+      default_title = Book.new.title
       book = Book.create(author: "Chico's", title: "Foo and Bar")
 
       book.destroy_key(:data, :author)
       expect(book.author).to be_nil
 
       book.destroy_key(:data, :title)
-      expect(book.title).to eq "Great Voyage"
+      expect(book.title).to eq default_title
     end
 
     it "updates the changes when saved" do
@@ -242,11 +243,12 @@ describe Storext do
     end
 
     it "clears the values from the proxy object" do
+      default_title = Book.new.title
       book = Book.create(author: "Chico's", title: "Foo and Bar")
       book.destroy_keys(:data, :author, :title)
 
       expect(book.author).to be_nil
-      expect(book.title).to eq "Great Voyage"
+      expect(book.title).to eq default_title
     end
 
     it "updates the changes when saved" do


### PR DESCRIPTION
Good housekeeping driven by a bug in storext-override:

https://github.com/G5/storext-override/issues/8