### PR TITLE
Fix: marshalling a model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Do not depend on Rails for non-development, ActiveRecord instead
 
+### Fixed
+- [Marshalling a model](https://github.com/G5/storext/issues/47)
+
 ## [2.2.2] - 2016-12-16
 ### Fixed
 - Reset values on proxy object when keys are destroyed on a storext object. Keeping these values leads to surprising behavior. See:

--- a/lib/storext/class_methods.rb
+++ b/lib/storext/class_methods.rb
@@ -80,6 +80,10 @@ module Storext
       end
     end
 
+    def _load(yml)
+      YAML.load(yml)
+    end
+
     private
 
     def storext_attrs_for(column)

--- a/lib/storext/instance_methods.rb
+++ b/lib/storext/instance_methods.rb
@@ -30,6 +30,10 @@ module Storext
       send(column).with_indifferent_access.has_key?(key)
     end
 
+    def _dump(level)
+      self.to_yaml
+    end
+
     private
 
     def set_storext_defaults

--- a/spec/storext_spec.rb
+++ b/spec/storext_spec.rb
@@ -295,4 +295,25 @@ describe Storext do
       end
     end
   end
+
+  describe "marshalling" do
+    it "can properly dump and load a non-persisted object" do
+      author = Author.new(name: "A. Clarke")
+      expect { Marshal.dump(author) }.to_not raise_error
+
+      dump = Marshal.dump(author)
+      author2 = Marshal.load(dump)
+      expect(author2.name).to eq "A. Clarke"
+    end
+
+    it "can properly dump and load a persisted object" do
+      author = Author.create(name: "A. Clarke")
+      expect { Marshal.dump(author) }.to_not raise_error
+
+      dump = Marshal.dump(author)
+      author2 = Marshal.load(dump)
+      expect(author2.name).to eq "A. Clarke"
+      expect(author2.id).to eq author.id
+    end
+  end
 end


### PR DESCRIPTION
Define the `#_dump` and `._load` methods in the classes that include `Storext.model`.  Use YAML to dump and load the models.