### PR TITLE
Fix: make Rails a development dependency

### DIFF
--- a/storext.gemspec
+++ b/storext.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pg"
   s.add_development_dependency "rspec"
   s.add_development_dependency "database_cleaner"
-  s.add_dependency "rails"
+  s.add_development_dependency "rails"
 end


### PR DESCRIPTION
Accidentally added it again as a runtime dependency before