### PR TITLE
Add support for rails 7.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Currently this gem uses [virtus](https://github.com/solnic/virtus) so you can pa
 
 ## Dependencies
 
-  * Rails 4.x, 5.x, 6.x
+  * Rails 4.x, 5.x, 6.x, 7.x
   * Virtus
 
 ## Installation

--- a/storext.gemspec
+++ b/storext.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "virtus"
-  s.add_dependency "activerecord", [">= 4.0", "< 6.2"]
+  s.add_dependency "activerecord", [">= 4.0", "<= 7.0.3"]
 
   s.add_development_dependency "pg"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
Adding support for rails 7.0.3 by changing the dependancy in storext.gemspec, and updating readme to reflect this change.